### PR TITLE
ingressClass support

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: dex
-version: 0.0.6
+version: 0.0.7
 appVersion: "2.28.0"
 kubeVersion: ">=1.14.0-0"
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.0.6](https://img.shields.io/badge/version-0.0.6-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.28.0](https://img.shields.io/badge/app%20version-2.28.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.0.7](https://img.shields.io/badge/version-0.0.7-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.28.0](https://img.shields.io/badge/app%20version-2.28.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors
 

--- a/charts/dex/templates/ingress.yaml
+++ b/charts/dex/templates/ingress.yaml
@@ -16,6 +16,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/charts/dex/templates/ingress.yaml
+++ b/charts/dex/templates/ingress.yaml
@@ -21,7 +21,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and (.Values.ingress.className) (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   {{- if .Values.ingress.tls }}

--- a/charts/dex/templates/ingress.yaml
+++ b/charts/dex/templates/ingress.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   {{- if .Values.ingress.className }}
   {{- if not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) -}}
-  {{- fail "Kubernetes version >=1.18 required to use className!" -}}
+  {{- fail "Kubernetes version >=1.18 required to use ingress.className!" -}}
   {{- end }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}

--- a/charts/dex/templates/ingress.yaml
+++ b/charts/dex/templates/ingress.yaml
@@ -11,15 +11,17 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "dex.labels" . | nindent 4 }}
+  {{- if and (.Values.ingress.className) (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+    {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+    {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+    {{- end }}
+  {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.ingress.className }}
-  {{- if not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) -}}
-  {{- fail "Kubernetes version >=1.18 required to use ingress.className!" -}}
-  {{- end }}
+  {{- if and (.Values.ingress.className) (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   {{- if .Values.ingress.tls }}

--- a/charts/dex/templates/ingress.yaml
+++ b/charts/dex/templates/ingress.yaml
@@ -17,6 +17,9 @@ metadata:
   {{- end }}
 spec:
   {{- if .Values.ingress.className }}
+  {{- if not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) -}}
+  {{- fail "Kubernetes version >=1.18 required to use className!" -}}
+  {{- end }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   {{- if .Values.ingress.tls }}

--- a/charts/dex/templates/ingress.yaml
+++ b/charts/dex/templates/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "dex.labels" . | nindent 4 }}
-  {{- if and (.Values.ingress.className) (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
     {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
     {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
     {{- end }}

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -120,7 +120,8 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
-  # ingressClassName support
+  # Sets Ingress/ingressClassName. This way ingress resources are able to bound specific ingress-controllers. Kubernetes version >=1.18 required. 
+  # See [Ingress documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class) for details.
   # className: ""
 
 # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -121,7 +121,7 @@ ingress:
   #    hosts:
   #      - chart-example.local
   # Sets Ingress/ingressClassName. This way ingress resources are able to bound specific ingress-controllers. Kubernetes version >=1.18 required.
-# See [Ingress documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class) for details.
+  # See [Ingress documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class) for details.
   # className: ""
 
 # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -120,6 +120,8 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+  # ingressClassName support
+  # className: ""
 
 # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workloads-resources/container/#resources) for details.

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -120,7 +120,7 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
-# Sets Ingress/ingressClassName. This way ingress resources are able to bound specific ingress-controllers. Kubernetes version >=1.18 required.
+  # Sets Ingress/ingressClassName. This way ingress resources are able to bound specific ingress-controllers. Kubernetes version >=1.18 required.
 # See [Ingress documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class) for details.
   # className: ""
 

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -120,7 +120,8 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
-  # Sets Ingress/ingressClassName. This way ingress resources are able to bound specific ingress-controllers. Kubernetes version >=1.18 required.
+
+  # -- Sets Ingress/ingressClassName. This way ingress resources are able to bound specific ingress-controllers. Kubernetes version >=1.18 required.
   # See [Ingress documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class) for details.
   # className: ""
 

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -120,8 +120,8 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
-  # Sets Ingress/ingressClassName. This way ingress resources are able to bound specific ingress-controllers. Kubernetes version >=1.18 required. 
-  # See [Ingress documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class) for details.
+# Sets Ingress/ingressClassName. This way ingress resources are able to bound specific ingress-controllers. Kubernetes version >=1.18 required.
+# See [Ingress documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class) for details.
   # className: ""
 
 # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).


### PR DESCRIPTION
This PR extends the charts with the possibility of using ingressClassName for ingress resources instead the deprecated ingress.classname annotation.
