### PR TITLE
feat: add external secret support

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: dex
-version: 0.2.0
+version: 0.3.0
 appVersion: "2.28.1"
 kubeVersion: ">=1.14.0-0"
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.2.0](https://img.shields.io/badge/version-0.2.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.28.1](https://img.shields.io/badge/app%20version-2.28.1-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.3.0](https://img.shields.io/badge/version-0.3.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.28.1](https://img.shields.io/badge/app%20version-2.28.1-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 
@@ -119,6 +119,8 @@ ingress:
 | fullnameOverride | string | `""` | A name to substitute for the full names of resources. |
 | https.enabled | bool | `false` | Enable the HTTPS endpoint. |
 | grpc.enabled | bool | `false` | Enable the gRPC endpoint. Read more in the [documentation](https://dexidp.io/docs/api/). |
+| configSecret.create | bool | `true` | Enable creating a secret from the values passed to `config`. If set to false, name must point to an existing secret. |
+| configSecret.name | string | `""` | The name of the secret to mount as configuration in the pod. If not set and create is true, a name is generated using the fullname template. Must point to secret that contains at least a `config.yaml` key. |
 | config | object | `{}` | Application configuration. See the [official documentation](https://dexidp.io/docs/). |
 | volumes | list | `[]` | Additional storage [volumes](https://kubernetes.io/docs/concepts/storage/volumes/). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1) for details. |
 | volumeMounts | list | `[]` | Additional [volume mounts](https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1) for details. |

--- a/charts/dex/ci/config-secret-values.yaml
+++ b/charts/dex/ci/config-secret-values.yaml
@@ -1,0 +1,10 @@
+config:
+  issuer: https://my-issuer.com
+
+  storage:
+    type: memory
+
+  enablePasswordDB: true
+
+configSecret:
+  name: my-super-special-dex-secret

--- a/charts/dex/templates/_helpers.tpl
+++ b/charts/dex/templates/_helpers.tpl
@@ -60,3 +60,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the name of the secret containing the config file to use
+*/}}
+{{- define "dex.configSecretName" -}}
+{{- if .Values.configSecret.create }}
+{{- default (include "dex.fullname" .) .Values.configSecret.name }}
+{{- else }}
+{{- default "default" .Values.configSecret.name }}
+{{- end }}
+{{- end }}

--- a/charts/dex/templates/deployment.yaml
+++ b/charts/dex/templates/deployment.yaml
@@ -96,7 +96,7 @@ spec:
       volumes:
         - name: config
           secret:
-            secretName: {{ include "dex.fullname" . }}
+            secretName: {{ include "dex.configSecretName" . }}
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/dex/templates/secret.yaml
+++ b/charts/dex/templates/secret.yaml
@@ -1,9 +1,11 @@
+{{ if .Values.configSecret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "dex.fullname" . }}
+  name: {{ include "dex.configSecretName" . }}
   labels:
     {{- include "dex.labels" . | nindent 4 }}
 type: Opaque
 data:
   config.yaml: {{ .Values.config | toYaml | b64enc | quote }}
+{{ end }}

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -33,6 +33,16 @@ grpc:
   # Read more in the [documentation](https://dexidp.io/docs/api/).
   enabled: false
 
+configSecret:
+  # -- Enable creating a secret from the values passed to `config`.
+  # If set to false, name must point to an existing secret.
+  create: true
+
+  # -- The name of the secret to mount as configuration in the pod.
+  # If not set and create is true, a name is generated using the fullname template.
+  # Must point to secret that contains at least a `config.yaml` key.
+  name: ""
+
 # -- Application configuration.
 # See the [official documentation](https://dexidp.io/docs/).
 config: {}


### PR DESCRIPTION
This PR adds external secret support.

This is useful to let the end user bring his own configuration from an existing secret.