### PR TITLE
Allow mounting in a secret with CA and TLS keys for GRPC API authentication

### DIFF
--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -120,6 +120,9 @@ ingress:
 | hostAliases | list | `[]` | A list of hosts and IPs that will be injected into the pod's hosts file if specified. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#hostname-and-name-resolution) |
 | https.enabled | bool | `false` | Enable the HTTPS endpoint. |
 | grpc.enabled | bool | `false` | Enable the gRPC endpoint. Read more in the [documentation](https://dexidp.io/docs/api/). |
+| grpc.authentication.enabled | bool | `false` | Enable TLS authentication secret for grpc api endpoint |
+| grpc.authentication.path | string | `"/etc/dex/tls"` | Secret mount path |
+| grpc.authentication.secret | string | `"dex-api-server-tls"` | Name of the secret to mount |
 | configSecret.create | bool | `true` | Enable creating a secret from the values passed to `config`. If set to false, name must point to an existing secret. |
 | configSecret.name | string | `""` | The name of the secret to mount as configuration in the pod. If not set and create is true, a name is generated using the fullname template. Must point to secret that contains at least a `config.yaml` key. |
 | config | object | `{}` | Application configuration. See the [official documentation](https://dexidp.io/docs/). |

--- a/charts/dex/templates/deployment.yaml
+++ b/charts/dex/templates/deployment.yaml
@@ -94,6 +94,11 @@ spec:
             - name: config
               mountPath: /etc/dex
               readOnly: true
+            {{- if and .Values.grpc.enabled .Values.grpc.authentication.enabled }}
+            - name: grpc-api-server-tls
+              mountPath: {{ .Values.grpc.authentication.path }}
+              readOnly: true
+            {{- end }}
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -101,6 +106,12 @@ spec:
         - name: config
           secret:
             secretName: {{ include "dex.configSecretName" . }}
+        {{- if and .Values.grpc.enabled .Values.grpc.authentication.enabled }}
+        - name: grpc-api-server-tls
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.grpc.authentication.secret }}
+        {{- end }}
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -36,6 +36,12 @@ grpc:
   # -- Enable the gRPC endpoint.
   # Read more in the [documentation](https://dexidp.io/docs/api/).
   enabled: false
+  # Optionally mount a secret with CA and TLS Key pair for api authentication
+  # Use value from tls.path in the config block - more in [documentation](https://dexidp.io/docs/api/#configuration)
+  authentication: 
+    enabled: false
+    path: /etc/dex/tls 
+    secret: dex-api-server-tls
 
 configSecret:
   # -- Enable creating a secret from the values passed to `config`.


### PR DESCRIPTION
Allows user to mount in a secret containing keys required to setup TLS authentication with the GRPC API.

Example:

Given a secret:

```
apiVersion: v1
data:
  tls.crt: ...
  tls.key: ...
  ca.crt: ...
kind: Secret
metadata:
  name: dex-grpc-server-tls
type: Opaque
```

and the chart values override with

```
...
grpc:
  enabled: true
  authentication: 
    enabled: true
    path: /etc/dex/tls 
    secret: dex-grpc-server-tls
config:
  grpc:
    tlsCert: /etc/dex/tls/tls.crt
    tlsKey: /etc/dex/tls/tls.key
    tlsClientCA: /etc/dex/tls/ca.crt
```

one can standup dex with a tls-authenticated API enpoint that can be exposed via an ingress, for example:

```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: dex-api-ingress
  annotations:
    kubernetes.io/ingress.class: ingress-nginx
    nginx.ingress.kubernetes.io/grpc-backend: "true"
    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
spec:
  rules:
  - host: dex-grpc.yourdomain.com
    http:
      paths:
      - backend:
          serviceName: dex-kubernetes-service-name
          servicePort: 8090
        path: /
  tls:
  - hosts:
    - dex-grpc.cnct.io
```