### PR TITLE
fix(charts/dex): add https to ingress

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: dex
-version: 0.6.5
+version: 0.6.6
 appVersion: "2.30.0"
 kubeVersion: ">=1.14.0-0"
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.6.5](https://img.shields.io/badge/version-0.6.5-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.30.0](https://img.shields.io/badge/app%20version-2.30.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.6.6](https://img.shields.io/badge/version-0.6.6-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.30.0](https://img.shields.io/badge/app%20version-2.30.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 

--- a/charts/dex/templates/ingress.yaml
+++ b/charts/dex/templates/ingress.yaml
@@ -1,6 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "dex.fullname" . -}}
 {{- $svcPort := .Values.service.ports.http.port -}}
+{{- if .Values.https.enabled -}}
+  {{- $svcPort = .Values.service.ports.https.port -}}
+{{- end }}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}


### PR DESCRIPTION
values.yaml:
```yaml
ingress:
  enabled: true
https:
  enabled: true
  ```
  It still directs to the http port.

Example:
 ```bash
 helm template dex ./charts/dex --set ingress.enabled=true --set https.enabled=true
 ```
 output:
 ```yaml
# Source: dex/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: dex
  labels:
    helm.sh/chart: dex-0.6.5
    app.kubernetes.io/name: dex
    app.kubernetes.io/instance: dex
    app.kubernetes.io/version: "2.30.0"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  ports:
    - name: http
      port: 5556
      targetPort: http
      protocol: TCP
      appProtocol: http
    - name: https
      port: 5554
      targetPort: https
      protocol: TCP
      appProtocol: https
    - name: telemetry
      port: 5558
      targetPort: telemetry
      protocol: TCP
      appProtocol: http
  selector:
    app.kubernetes.io/name: dex
    app.kubernetes.io/instance: dex
---
# Source: dex/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: dex
  labels:
    helm.sh/chart: dex-0.6.5
    app.kubernetes.io/name: dex
    app.kubernetes.io/instance: dex
    app.kubernetes.io/version: "2.30.0"
    app.kubernetes.io/managed-by: Helm
spec:
  rules:
    - host: "chart-example.local"
      http:
        paths:
          - path: /
            pathType: ImplementationSpecific
            backend:
              service:
                name: dex
                port:
                  number: 5556
 ```
ingress still routes traffic to the http port (5556) =(. I fixed it