### PR TITLE
Adding pathType to ingress paths exemple

### DIFF
--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -45,6 +45,7 @@ ingress:
     - host: my-issuer-url.com
       paths:
         - path: /
+          pathType: ImplementationSpecific # pathType is needed for Kubernetes 1.19+
 ```
 
 ### Minimal TLS configuration
@@ -99,6 +100,7 @@ ingress:
     - host: my-issuer-url.com
       paths:
         - path: /
+          pathType: ImplementationSpecific # pathType is needed for Kubernetes 1.19+
 
   tls:
     - hosts:


### PR DESCRIPTION
As part for the change in the Ingress API version Kubernetes have added the required field `pathType`. We need to specify it in the helm variable.

Signed-off-by: Justin Brûlotte <justin.brlotte797@gmail.com>