### PR TITLE
Load balancer service option

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -24,7 +24,7 @@ annotations:
     - kind: added
       description: "`clusterIP` value to control the IP when using ClusterIP service type"
     - kind: added
-      description: "`loadBalancerIP` configuration option added to helm chart"
+      description: "`loadBalancerIP` value to control the IP when using LoadBalancer service type"
   artifacthub.io/images: |
     - name: dex
       image: ghcr.io/dexidp/dex:v2.30.0

--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: dex
-version: 0.6.3
+version: 0.6.4
 appVersion: "2.30.0"
 kubeVersion: ">=1.14.0-0"
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
@@ -23,6 +23,8 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: "`clusterIP` value to control the IP when using ClusterIP service type"
+    - kind: added
+      description: "`loadBalancerIP` configuration option added to helm chart"
   artifacthub.io/images: |
     - name: dex
       image: ghcr.io/dexidp/dex:v2.30.0

--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -22,8 +22,6 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "`clusterIP` value to control the IP when using ClusterIP service type"
-    - kind: added
       description: "`loadBalancerIP` value to control the IP when using LoadBalancer service type"
   artifacthub.io/images: |
     - name: dex

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -141,6 +141,7 @@ ingress:
 | service.annotations | object | `{}` | Annotations to be added to the service. |
 | service.type | string | `"ClusterIP"` | Kubernetes [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). |
 | service.clusterIP | string | `""` | Internal cluster service IP (when applicable) |
+| service.loadBalancerIP | string | `nil` | External cluster service IP (when applicable) |
 | service.ports.http.port | int | `5556` | HTTP service port |
 | service.ports.http.nodePort | int | `nil` | HTTP node port (when applicable) |
 | service.ports.https.port | int | `5554` | HTTPS service port |

--- a/charts/dex/templates/service.yaml
+++ b/charts/dex/templates/service.yaml
@@ -13,6 +13,9 @@ spec:
   {{- with .Values.service.clusterIP }}
   clusterIP: {{ . }}
   {{- end }}
+  {{- with .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
   ports:
     - name: http
       port: {{ .Values.service.ports.http.port }}

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -125,7 +125,7 @@ service:
   # -- Internal cluster service IP (when applicable)
   clusterIP: ""
   
-  # -- External loadBalancer IP (when applicable)
+  # -- Load balancer IP (when applicable)
   loadBalancerIP:
 
   ports:

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -124,6 +124,9 @@ service:
 
   # -- Internal cluster service IP (when applicable)
   clusterIP: ""
+  
+  # -- External loadBalancer IP (when applicable)
+  loadBalancerIP: ""
 
   ports:
     http:

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -126,7 +126,7 @@ service:
   clusterIP: ""
   
   # -- External loadBalancer IP (when applicable)
-  loadBalancerIP: ""
+  loadBalancerIP:
 
   ports:
     http:


### PR DESCRIPTION


#### Overview

Add loadBalancerIP option to manually define an IP address when service type loadBalancer is defined.

#### What this PR does / why we need it

The helm chart currently has the option to define a service type but if service type is set to loadBalancer then there is no option to define a loadBalancerIP. The service type loadBalancer with loadBalancerIP option exposes the dex service externally with a defined load balancer IP for those instances where a load balancer IP cannot be assigned dynamically.

#### Special notes for your reviewer

#### Checklist

- [] Change log updated in `Chart.yaml` (see the contributing guide for details)
- [] Chart version bumped in `Chart.yaml` (see the contributing guide for details)
- [] Documentation regenerated by running `make docs`
