### PR TITLE
Add NetworkPolicy

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -21,8 +21,8 @@ maintainers:
     url: https://sagikazarmark.hu
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Update Dex to 2.34.0"
+    - kind: added
+      description: "`networkPolicy` value to enable network policy and define optional custom Egress rules"
   artifacthub.io/images: |
     - name: dex
       image: ghcr.io/dexidp/dex:v2.34.0

--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: dex
-version: 0.11.0
+version: 0.11.1
 appVersion: "2.34.0"
 kubeVersion: ">=1.14.0-0"
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.11.0](https://img.shields.io/badge/version-0.11.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.34.0](https://img.shields.io/badge/app%20version-2.34.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.11.1](https://img.shields.io/badge/version-0.11.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.34.0](https://img.shields.io/badge/app%20version-2.34.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 
@@ -166,6 +166,7 @@ ingress:
 | affinity | object | `{}` | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) configuration. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details. |
 | topologySpreadConstraints | list | `[]` | [TopologySpreadConstraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) configuration. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details. |
 | strategy | object | `{}` | Deployment [strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) configuration. |
+| networkPolicy | object | Disabled by default. | [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) configuration (see [values.yaml](values.yaml) for details). |
 
 ## Migrating from stable/dex (or banzaicloud-stable/dex) chart
 

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -166,7 +166,8 @@ ingress:
 | affinity | object | `{}` | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) configuration. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details. |
 | topologySpreadConstraints | list | `[]` | [TopologySpreadConstraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) configuration. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details. |
 | strategy | object | `{}` | Deployment [strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) configuration. |
-| networkPolicy | object | Disabled by default. | [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) configuration (see [values.yaml](values.yaml) for details). |
+| networkPolicy.enabled | bool | `false` | Create [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) |
+| networkPolicy.egressRules | list | `[]` | A list of network policy egress rules |
 
 ## Migrating from stable/dex (or banzaicloud-stable/dex) chart
 

--- a/charts/dex/templates/networkpolicy.yaml
+++ b/charts/dex/templates/networkpolicy.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.networkPolicy.enabled }}
+{{- if semverCompare "<1.7-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: extensions/v1beta1
+{{- else -}}
+apiVersion: networking.k8s.io/v1
+{{- end }}
+kind: NetworkPolicy
+metadata:
+  name: {{ include "dex.fullname" . }}
+  labels:
+    {{- include "dex.labels" . | nindent 4 }}
+spec:
+  policyTypes:
+    - Egress
+    - Ingress
+  podSelector:
+    matchLabels:
+      {{- include "dex.selectorLabels" . | nindent 6 }}
+  ingress:
+    - ports:
+        - port: http
+        {{- if .Values.https.enabled }}
+        - port: https
+        {{- end }}
+        {{- if .Values.grpc.enabled }}
+        - port: grpc
+        {{- end }}
+        - port: telemetry
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    {{- if .Values.networkPolicy.egressRules }}
+    {{- toYaml .Values.networkPolicy.egressRules | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/dex/templates/networkpolicy.yaml
+++ b/charts/dex/templates/networkpolicy.yaml
@@ -11,7 +11,9 @@ metadata:
     {{- include "dex.labels" . | nindent 4 }}
 spec:
   policyTypes:
+    {{- if .Values.networkPolicy.egressRules }}
     - Egress
+    {{- end }}
     - Ingress
   podSelector:
     matchLabels:
@@ -26,13 +28,8 @@ spec:
         - port: grpc
         {{- end }}
         - port: telemetry
+  {{- with .Values.networkPolicy.egressRules }}
   egress:
-    - ports:
-        - port: 53
-          protocol: UDP
-        - port: 53
-          protocol: TCP
-    {{- if .Values.networkPolicy.egressRules }}
-    {{- toYaml .Values.networkPolicy.egressRules | nindent 4 }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -256,3 +256,16 @@ strategy: {}
   # rollingUpdate:
   #   maxUnavailable: 1
   # type: RollingUpdate
+
+# -- [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) configuration (see [values.yaml](values.yaml) for details).
+# @default -- Disabled by default.
+networkPolicy:
+  enabled: false
+  egressRules: []
+  # Example to allow LDAP connector to reach LDAPs port on 1.2.3.4 server
+  #  - to:
+  #      - ipBlock
+  #          cidr: 1.2.3.4/32
+  #    ports:
+  #      - port: 636
+  #        protocol: TCP

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -260,8 +260,16 @@ strategy: {}
 # -- [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) configuration (see [values.yaml](values.yaml) for details).
 # @default -- Disabled by default.
 networkPolicy:
+  # -- Create [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
   enabled: false
+  # -- A list of network policy egress rules
   egressRules: []
+  # Allow DNS egress traffic
+  # - ports:
+  #     - port: 53
+  #       protocol: UDP
+  #     - port: 53
+  #       protocol: TCP
   # Example to allow LDAP connector to reach LDAPs port on 1.2.3.4 server
   #  - to:
   #      - ipBlock

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -257,8 +257,6 @@ strategy: {}
   #   maxUnavailable: 1
   # type: RollingUpdate
 
-# -- [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) configuration (see [values.yaml](values.yaml) for details).
-# @default -- Disabled by default.
 networkPolicy:
   # -- Create [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
   enabled: false


### PR DESCRIPTION
#### Overview

Add the ability to create a network policy with customizable egress

#### What this PR does / why we need it
Network policies are a best practice.
Specifically when deploying in a NS already containing network policies, it is required.


#### Special notes for your reviewer
N/A
#### Checklist

- [x] Change log updated in `Chart.yaml` (see the contributing guide for details)
- [x] Chart version bumped in `Chart.yaml` (see the contributing guide for details)
- [x] Documentation regenerated by running `make docs`
