### PR TITLE
fix(charts/dex): fix render error caused by #71

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: dex
-version: 0.6.6
+version: 0.6.7
 appVersion: "2.30.0"
 kubeVersion: ">=1.14.0-0"
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
@@ -21,8 +21,8 @@ maintainers:
     url: https://sagikazarmark.hu
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "`topologySpreadConstraints` value to allow use topology spread constraints in the Dex deployment"
+    - kind: fixed
+      description: "Fixed template rendering around error `nil pointer evaluating interface {}.topologySpreadConstraints`"
   artifacthub.io/images: |
     - name: dex
       image: ghcr.io/dexidp/dex:v2.30.0

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.6.6](https://img.shields.io/badge/version-0.6.6-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.30.0](https://img.shields.io/badge/app%20version-2.30.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.6.7](https://img.shields.io/badge/version-0.6.7-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.30.0](https://img.shields.io/badge/app%20version-2.30.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 

--- a/charts/dex/templates/deployment.yaml
+++ b/charts/dex/templates/deployment.yaml
@@ -123,10 +123,10 @@ spec:
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:


### PR DESCRIPTION
#### Overview

In chart version 0.6.6 (#71), the template rendering broke because it tries to use `.Values.topologySpreadConstraints` while still within the `.Values.affinity` scope. This lead to an error like the following:

```
Error: template: dex/templates/deployment.yaml:126:22: executing "dex/templates/deployment.yaml" at <.Values.topologySpreadConstraints>: nil pointer evaluating interface {}.topologySpreadConstraints
```

#### What this PR does / why we need it

Moves the rendering of `topologySpreadConstraints` outside the scope of the `.Values.affinity` block.

#### Special notes for your reviewer

#### Checklist

- [x] Change log updated in `Chart.yaml` (see the contributing guide for details)
- [x] Chart version bumped in `Chart.yaml` (see the contributing guide for details)
- [x] Documentation regenerated by running `make docs`
