### PR TITLE
Fixes cluster role, broken in recent change

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: dex
-version: 0.8.1
+version: 0.8.2
 appVersion: "2.31.1"
 kubeVersion: ">=1.14.0-0"
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
@@ -22,7 +22,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "`ClusterRole` and `ClusterRoleBilding` to `Role` and `RoleBinding` to allow Deployments without ClusterPermissions"
+      description: "Fixes: `ClusterRole` and `ClusterRoleBilding` to `Role` and `RoleBinding` to allow Deployments without ClusterPermissions"
   artifacthub.io/images: |
     - name: dex
       image: ghcr.io/dexidp/dex:v2.31.1

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.8.1](https://img.shields.io/badge/version-0.8.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.31.1](https://img.shields.io/badge/app%20version-2.31.1-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.8.2](https://img.shields.io/badge/version-0.8.2-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.31.1](https://img.shields.io/badge/app%20version-2.31.1-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 

--- a/charts/dex/templates/rbac.yaml
+++ b/charts/dex/templates/rbac.yaml
@@ -38,7 +38,7 @@ rules:
     verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: {{ include "dex.fullname" . }}-cluster
   labels:


### PR DESCRIPTION
Error in 651bf428522a9896ca93127966abd7905c8374d9

The cluster role enablement section installs as a RoleBinding vs.
ClusterRoleBinding. The corrects it.

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
5. Check out the contributing guide for more details.
-->

#### Overview

Error in commit 651bf428522a9896ca93127966abd7905c8374d9

The cluster role enablement section installs as a RoleBinding vs.
ClusterRoleBinding, disallowing dex from adding CRDs. The corrects it.

<!-- Describe your changes briefly here. -->

Changes the definition to the correct resource type, fixing the error.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Checklist

- [x] Change log updated in `Chart.yaml` (see the contributing guide for details)
- [x] Chart version bumped in `Chart.yaml` (see the contributing guide for details)
- [x] Documentation regenerated by running `make docs`
