### PR TITLE
Feature: config in a ConfigMap

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: dex
-version: 0.8.2
+version: 0.9.0
 appVersion: "2.31.1"
 kubeVersion: ">=1.14.0-0"
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.8.2](https://img.shields.io/badge/version-0.8.2-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.31.1](https://img.shields.io/badge/app%20version-2.31.1-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.9.0](https://img.shields.io/badge/version-0.9.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.31.1](https://img.shields.io/badge/app%20version-2.31.1-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 
@@ -120,8 +120,11 @@ ingress:
 | hostAliases | list | `[]` | A list of hosts and IPs that will be injected into the pod's hosts file if specified. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#hostname-and-name-resolution) |
 | https.enabled | bool | `false` | Enable the HTTPS endpoint. |
 | grpc.enabled | bool | `false` | Enable the gRPC endpoint. Read more in the [documentation](https://dexidp.io/docs/api/). |
-| configSecret.create | bool | `true` | Enable creating a secret from the values passed to `config`. If set to false, name must point to an existing secret. |
-| configSecret.name | string | `""` | The name of the secret to mount as configuration in the pod. If not set and create is true, a name is generated using the fullname template. Must point to secret that contains at least a `config.yaml` key. |
+| configType | string | `"secret"` | The manifest type from which the content of the `config` should be resolved from. Can be `secret` or `configMap`. |
+| configSecret.create | bool | `true` | Enable creating a secret from the values passed to `config`. If set to false, name must point to an existing secret. Only active when `configType` is `secret`. |
+| configSecret.name | string | `""` | The name of the secret to mount as configuration in the pod. If not set and create is true, a name is generated using the fullname template. Must point to secret that contains at least a `config.yaml` key. Only active when `configType` is `secret`. |
+| configMap.create | bool | `true` | Enable creating a configMap from the values passed to `config`. If set to false, name must point to an existing config map. Only active when `configType` is `configMap`. |
+| configMap.name | string | `""` | The name of the configMap to mount as configuration in the pod. If not set and create is true, a name is generated using the fullname template. Must point to configMap that contains at least a `config.yaml` key. Only active when `configType` is `configMap`. |
 | config | object | `{}` | Application configuration. See the [official documentation](https://dexidp.io/docs/). |
 | volumes | list | `[]` | Additional storage [volumes](https://kubernetes.io/docs/concepts/storage/volumes/). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1) for details. |
 | volumeMounts | list | `[]` | Additional [volume mounts](https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1) for details. |

--- a/charts/dex/templates/_helpers.tpl
+++ b/charts/dex/templates/_helpers.tpl
@@ -71,3 +71,14 @@ Create the name of the secret containing the config file to use
 {{- default "default" .Values.configSecret.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the name of the configMap containing the config file to use
+*/}}
+{{- define "dex.configMapName" -}}
+{{- if .Values.configMap.create }}
+{{- default (include "dex.fullname" .) .Values.configMap.name }}
+{{- else }}
+{{- default "default" .Values.configMap.name }}
+{{- end }}
+{{- end }}

--- a/charts/dex/templates/configmap.yaml
+++ b/charts/dex/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if and (eq .Values.configType "configMap") .Values.configSecret.create -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "dex.configMapName" . }}
+  labels:
+    {{- include "dex.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{ .Values.config | toYaml | indent 4 }}
+{{- end }}

--- a/charts/dex/templates/configmap.yaml
+++ b/charts/dex/templates/configmap.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "dex.labels" . | nindent 4 }}
 data:
   config.yaml: |
-    {{ .Values.config | toYaml | indent 4 }}
+{{ .Values.config | toYaml | indent 4 }}
 {{- end }}

--- a/charts/dex/templates/deployment.yaml
+++ b/charts/dex/templates/deployment.yaml
@@ -110,9 +110,15 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
+        {{- if eq .Values.configType "secret" }}
         - name: config
           secret:
             secretName: {{ include "dex.configSecretName" . }}
+        {{- else if eq .Values.configType "configMap" }}
+        - name: config
+          configMap:
+            mame: {{ include "dex.configMapName" . }}
+        {{- end }}
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/dex/templates/secret.yaml
+++ b/charts/dex/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.configSecret.create -}}
+{{- if and (eq .Values.configType "secret") .Values.configSecret.create -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -39,7 +39,7 @@ grpc:
 
 
 # -- The manifest type from which the content of the `config` should be resolved from.
-# Con be `secret` or `configMap`.
+# Can be `secret` or `configMap`.
 configType: secret
 
 configSecret:

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -37,14 +37,33 @@ grpc:
   # Read more in the [documentation](https://dexidp.io/docs/api/).
   enabled: false
 
+
+# -- The manifest type from which the content of the `config` should be resolved from.
+# Con be `secret` or `configMap`.
+configType: secret
+
 configSecret:
   # -- Enable creating a secret from the values passed to `config`.
   # If set to false, name must point to an existing secret.
+  # Only active when `configType` is `secret`.
   create: true
 
   # -- The name of the secret to mount as configuration in the pod.
   # If not set and create is true, a name is generated using the fullname template.
   # Must point to secret that contains at least a `config.yaml` key.
+  # Only active when `configType` is `secret`.
+  name: ""
+
+configMap:
+  # -- Enable creating a configMap from the values passed to `config`.
+  # If set to false, name must point to an existing config map.
+  # Only active when `configType` is `configMap`.
+  create: true
+
+  # -- The name of the configMap to mount as configuration in the pod.
+  # If not set and create is true, a name is generated using the fullname template.
+  # Must point to configMap that contains at least a `config.yaml` key.
+  # Only active when `configType` is `configMap`.
   name: ""
 
 # -- Application configuration.


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
5. Check out the contributing guide for more details.
-->

#### Overview

This PR adds the option to use a ConfigMap to store the content of `config`.

#### What this PR does / why we need it

Closes #83

#### Special notes for your reviewer

#### Checklist

- [x] Change log updated in `Chart.yaml` (see the contributing guide for details)
- [x] Chart version bumped in `Chart.yaml` (see the contributing guide for details)
- [x] Documentation regenerated by running `make docs`
