### PR TITLE
Add: support common labels for all resources

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -21,8 +21,8 @@ maintainers:
     url: https://sagikazarmark.hu
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Update Dex to 2.35.3"
+    - kind: added
+      description: "Common labels to all resources created by the chart"
   artifacthub.io/images: |
     - name: dex
       image: ghcr.io/dexidp/dex:v2.35.3

--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: dex
-version: 0.8.3
-appVersion: "2.31.1"
+version: 0.13.0
+appVersion: "2.35.1"
 kubeVersion: ">=1.14.0-0"
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 icon: https://dexidp.io/favicon.png

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -111,6 +111,7 @@ ingress:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | replicaCount | int | `1` | Number of replicas (pods) to launch. |
+| commonLabels | object | `{}` | Labels to apply to all resources and selectors. |
 | image.repository | string | `"ghcr.io/dexidp/dex"` | Name of the image repository to pull the container image from. |
 | image.pullPolicy | string | `"IfNotPresent"` | [Image pull policy](https://kubernetes.io/docs/concepts/containers/images/#updating-images) for updating already existing images on a node. |
 | image.tag | string | `""` | Image tag override for the default value (chart appVersion). |

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.12.1](https://img.shields.io/badge/version-0.12.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.35.3](https://img.shields.io/badge/app%20version-2.35.3-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.13.0](https://img.shields.io/badge/version-0.13.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.35.3](https://img.shields.io/badge/app%20version-2.35.3-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 

--- a/charts/dex/templates/_helpers.tpl
+++ b/charts/dex/templates/_helpers.tpl
@@ -48,6 +48,9 @@ Selector labels
 {{- define "dex.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "dex.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -5,6 +5,10 @@
 # -- Number of replicas (pods) to launch.
 replicaCount: 1
 
+# -- Labels to apply to all resources and selectors.
+commonLabels: {}
+# team_name: dev
+
 image:
   # -- Name of the image repository to pull the container image from.
   repository: ghcr.io/dexidp/dex


### PR DESCRIPTION
Usefull when we have a policies manager as Kyverno.

Signed-off-by: Flaagada <mary.thibault2@gmail.com>

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
5. Check out the contributing guide for more details.
-->

#### Overview

Support a common labels for all resources.

#### What this PR does / why we need it

When we used a policies manager as Kyverno, it's usefull to be able to add a common labels on all resources created by the chart in order to respect the policy.

#### Special notes for your reviewer

#### Checklist

- [x] Change log updated in `Chart.yaml` (see the contributing guide for details)
- [x] Chart version bumped in `Chart.yaml` (see the contributing guide for details)
- [x] Documentation regenerated by running `make docs`
