### PR TITLE
Use HTTPS port for Ingress when enabled

### DIFF
--- a/charts/dex/templates/ingress.yaml
+++ b/charts/dex/templates/ingress.yaml
@@ -1,6 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "dex.fullname" . -}}
 {{- $svcPort := .Values.service.ports.http.port -}}
+{{- if .Values.https.enabled -}}
+{{- $svcPort = .Values.service.ports.https.port -}}
+{{- end -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -178,6 +178,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+    # nginx.ingress.kubernetes.io/backend-protocol: HTTPS
 
   # -- Ingress host configuration.
   # @default -- See [values.yaml](values.yaml).


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
5. Check out the contributing guide for more details.
-->

#### Overview
When enabling HTTPS, the ingress still forwards traffic to the service over HTTP. This PR sets the destination port to the HTTPS port when `.Values.https.enabled` is true.

#### What this PR does / why we need it
Enabling HTTPS currently does nothing for the communication between the ingress and the service, defeating the purpose altogether. With this PR HTTPS is also used between the service and ingress (when complemented with the necessary annotation for nginx).

#### Special notes for your reviewer

#### Checklist

- [x] Change log updated in `Chart.yaml` (see the contributing guide for details)
- [x] Chart version bumped in `Chart.yaml` (see the contributing guide for details)
- [x] Documentation regenerated by running `make docs`


Signed-off-by: Joost Buskermolen <joost@buskervezel.nl>