### PR TITLE
Use HTTPS port in Ingress when enabled

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: dex
-version: 0.12.1
+version: 0.13.0
 appVersion: "2.35.3"
 kubeVersion: ">=1.14.0-0"
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
@@ -21,8 +21,8 @@ maintainers:
     url: https://sagikazarmark.hu
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Update Dex to 2.35.3"
+    - kind: added
+      description: Enable HTTPS communication between Ingress and Service when ingress.https is true.
   artifacthub.io/images: |
     - name: dex
       image: ghcr.io/dexidp/dex:v2.35.3

--- a/charts/dex/templates/ingress.yaml
+++ b/charts/dex/templates/ingress.yaml
@@ -1,6 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "dex.fullname" . -}}
 {{- $svcPort := .Values.service.ports.http.port -}}
+{{- if .Values.ingress.https -}}
+{{- $svcPort = .Values.service.ports.https.port -}}
+{{- end }}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -171,6 +171,9 @@ ingress:
   # -- Enable [ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/).
   enabled: false
 
+  # -- Enable ingress to target https container port, https.enabled must be true
+  https: false
+
   # -- Ingress [class name](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class).
   className: ""
 


### PR DESCRIPTION
**Overview**

When enabling HTTPS, the ingress still forwards traffic to the service over HTTP. This PR sets the destination port to the HTTPS port when .Values.https.enabled is true.

**What this PR does / why we need it**

Enabling HTTPS currently does nothing for the communication between the ingress and the service, defeating the purpose altogether. With this PR HTTPS is also used between the service and ingress (when complemented with the necessary annotation for nginx).

**Special notes for your reviewer**

**Checklist**

- [x]  Change log updated in Chart.yaml (see the contributing guide for details)
- [x]  Chart version bumped in Chart.yaml (see the contributing guide for details)
- [ ]  Documentation regenerated by running make docs