### PR TITLE
Add sidecar container possibility in deployments

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "Common labels to all resources created by the chart"
+      description: "Add sidecar container possibility in deployment chart"
   artifacthub.io/images: |
     - name: dex
       image: ghcr.io/dexidp/dex:v2.35.3

--- a/charts/dex/templates/deployment.yaml
+++ b/charts/dex/templates/deployment.yaml
@@ -109,6 +109,22 @@ spec:
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- if .Values.sidecarContainer }}
+        - name: "{{ .Values.sidecarContainer.name }}"
+          image: "{{ .Values.sidecarContainer.repository }}:
+                  {{ .Values.sidecarContainer.tag }}"
+          imagePullPolicy: {{ .Values.sidecarContainer.pullPolicy }}
+          ports:
+          {{- with .Values.sidecarContainer.ports }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.sidecarContainer.volumeMounts }}
+          volumeMounts:
+          {{- with .Values.sidecarContainer.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
+        {{- end }}
       volumes:
         - name: config
           secret:

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -279,3 +279,19 @@ networkPolicy:
   #    ports:
   #      - port: 636
   #        protocol: TCP
+
+# Allow extra sidecar container
+sidecarContainer: ""
+  # Example of sidecar configuration
+  # name: dex-sidecar-nginx-proxy
+  # repository: ghcr.io/nginxinc/nginx-unprivileged
+  # tag: 1.23.3
+  # pullPolicy: IfNotPresent
+  # volumeMounts:
+  #   - mountPath: /etc/nginx
+  #     name: nginx-conf
+  #     readOnly: true
+  # ports:
+  #   - containerPort: 8443
+  #     https-nginx
+  #     protocol: TCP


### PR DESCRIPTION
Signed-off-by: Benjamin Fernandez <fernandez.benjamin@outlook.com>


Overview
Provide a way to use sidecar container (for example nginx)
This Pull Request is complementary of the pull request on dex app :
https://github.com/dexidp/dex/pull/2266
We are facing an issue with dex which seems to be vulnerable to clickjacking. We would like to get a way to configure the Content Security Policy frame-ancestor context to prevent clickjacking.


What this PR does / why we need it
This PR will permit to put a proxy sidecar container to be able to enables the configuration of the Content-Security policy to prevent clickjacking. By filling sidecar container configuration with the specific fields the application will send csp headers in responses defining the content security policy.
To do so we try to use an nginx sidecar container which work really well for frame ancestors with proper headers.

The sidecar container is not required so if the sidecar container is not set the sidecar upgrade in helm charts will not impact other users

Special notes for your reviewer
The most critical endpoints for clickjacking is the /dex/auth one (as a user interaction is needed to provide credential) but by default it is a good point to apply the same policy for all endpoints

Does this PR introduce a user-facing change?
NONE

