### PR TITLE
feat(charts/dex): use updated HorizontalPodAutoscaler API Version

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: dex
-version: 0.14.0
+version: 0.14.1
 appVersion: "2.36.0"
 kubeVersion: ">=1.14.0-0"
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
@@ -22,7 +22,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "Common labels to all resources created by the chart"
+      description: "Use updated HorizontalPodAutoscaler API Version which is no longer served in K8s >=1.25"
   artifacthub.io/images: |
     - name: dex
       image: ghcr.io/dexidp/dex:v2.36.0

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.14.0](https://img.shields.io/badge/version-0.14.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.36.0](https://img.shields.io/badge/app%20version-2.36.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.14.1](https://img.shields.io/badge/version-0.14.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.36.0](https://img.shields.io/badge/app%20version-2.36.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 

--- a/charts/dex/templates/hpa.yaml
+++ b/charts/dex/templates/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.autoscaling.enabled }}
+{{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: autoscaling/v2
+{{- else -}}
 apiVersion: autoscaling/v2beta1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "dex.fullname" . }}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
5. Check out the contributing guide for more details.
-->

#### Overview

<!-- Describe your changes briefly here. -->

Use updated autoscaling API Version for HorizontalPodAutoscaler.

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

The `autoscaling/v2beta1` API version of HorizontalPodAutoscaler isn't served on K8s versions >=1.25. The Dex chart should support the newer version of the API, `autoscaling/v2` which is available on K8s versions >=1.23.

#### Special notes for your reviewer

#### Checklist

- [x] Change log updated in `Chart.yaml` (see the contributing guide for details)
- [x] Chart version bumped in `Chart.yaml` (see the contributing guide for details)
- [x] Documentation regenerated by running `make docs`
