### PR TITLE
fix: add missing defaults on servicemonitor

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -21,8 +21,8 @@ maintainers:
     url: https://sagikazarmark.hu
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "Fixed error stemming from the formatting of the new autoscaling API version"
+    - kind: added
+      description: "Add default values for path and honorLabels to ServiceMonitor"
   artifacthub.io/images: |
     - name: dex
       image: ghcr.io/dexidp/dex:v2.37.0

--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: dex
-version: 0.15.2
+version: 0.15.3
 appVersion: "2.37.0"
 kubeVersion: ">=1.14.0-0"
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.15.2](https://img.shields.io/badge/version-0.15.2-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.37.0](https://img.shields.io/badge/app%20version-2.37.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.15.3](https://img.shields.io/badge/version-0.15.3-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.37.0](https://img.shields.io/badge/app%20version-2.37.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -166,8 +166,10 @@ ingress:
 | serviceMonitor.labels | object | `{}` | Labels to be added to the ServiceMonitor. |
 | serviceMonitor.annotations | object | `{}` | Annotations to be added to the ServiceMonitor. |
 | serviceMonitor.scheme | string | `""` | HTTP scheme to use for scraping. Can be used with `tlsConfig` for example if using istio mTLS. |
+| serviceMonitor.path | string | `"/metrics"` | HTTP path to scrape for metrics. |
 | serviceMonitor.tlsConfig | object | `{}` | TLS configuration to use when scraping the endpoint. For example if using istio mTLS. |
 | serviceMonitor.bearerTokenFile | string | `nil` | Prometheus scrape bearerTokenFile |
+| serviceMonitor.honorLabels | bool | `false` | HonorLabels chooses the metric's labels on collisions with target labels. |
 | serviceMonitor.metricRelabelings | list | `[]` | Prometheus scrape metric relabel configs to apply to samples before ingestion. |
 | serviceMonitor.relabelings | list | `[]` | Relabel configs to apply to samples before ingestion. |
 | resources | object | No requests or limits. | Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details. |

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -238,6 +238,9 @@ serviceMonitor:
   # Can be used with `tlsConfig` for example if using istio mTLS.
   scheme: ""
 
+  # -- HTTP path to scrape for metrics.
+  path: /metrics
+
   # -- TLS configuration to use when scraping the endpoint.
   # For example if using istio mTLS.
   ## Of type: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig
@@ -245,6 +248,9 @@ serviceMonitor:
 
   # -- Prometheus scrape bearerTokenFile
   bearerTokenFile:
+
+  # -- HonorLabels chooses the metric's labels on collisions with target labels.
+  honorLabels: false
 
   # -- Prometheus scrape metric relabel configs
   # to apply to samples before ingestion.


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
5. Check out the contributing guide for more details.
-->

#### Overview

Add missing default values on ServiceMonitor.

#### What this PR does / why we need it

In https://github.com/dexidp/helm-charts/pull/105 two new values, `.Values.serviceMonitor.honorLabels` and `.Values.serviceMonitor.path`, was introduced without any default values. If these values are not set by the user the value become `null` and installation in a k8s cluster fails. 

#### Special notes for your reviewer

#### Checklist

- [x] Change log updated in `Chart.yaml` (see the contributing guide for details)
- [x] Chart version bumped in `Chart.yaml` (see the contributing guide for details)
- [x] Documentation regenerated by running `make docs`
