### PR TITLE
fix(charts/dex): Templating error caused by #111

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: dex
-version: 0.14.3
+version: 0.14.4
 appVersion: "2.36.0"
 kubeVersion: ">=1.14.0-0"
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
@@ -21,8 +21,8 @@ maintainers:
     url: https://sagikazarmark.hu
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "Use updated HorizontalPodAutoscaler API Version which is no longer served in K8s >=1.25"
+    - kind: fixed
+      description: "Fixed error stemming from the formatting of the new autoscaling API version"
   artifacthub.io/images: |
     - name: dex
       image: ghcr.io/dexidp/dex:v2.36.0

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.14.3](https://img.shields.io/badge/version-0.14.3-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.36.0](https://img.shields.io/badge/app%20version-2.36.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.14.4](https://img.shields.io/badge/version-0.14.4-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.36.0](https://img.shields.io/badge/app%20version-2.36.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 

--- a/charts/dex/templates/hpa.yaml
+++ b/charts/dex/templates/hpa.yaml
@@ -18,14 +18,14 @@ spec:
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
     {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
-    {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion -}}
+    {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion }}
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
-    {{- else -}}
+    {{- else }}
     - type: Resource
       resource:
         name: cpu
@@ -33,14 +33,14 @@ spec:
     {{- end }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
-    {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion -}}
+    {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion }}
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
-    {{- else -}}
+    {{- else }}
     - type: Resource
       resource:
         name: memory

--- a/charts/dex/templates/hpa.yaml
+++ b/charts/dex/templates/hpa.yaml
@@ -18,15 +18,33 @@ spec:
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
     {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion -}}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- else -}}
     - type: Resource
       resource:
         name: cpu
         targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
+    {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion -}}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- else -}}
     - type: Resource
       resource:
         name: memory
         targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
5. Check out the contributing guide for more details.
-->

#### Overview

<!-- Describe your changes briefly here. -->

In chart version 0.14.3 (#111), the API Version of the Autoscaling object was updated to address an upstream API version deprecation in Kubernetes 1.25. However, the formatting under the `.spec.metrics[]` field changed which was not caught in testing. This would lead to the error below:

```
Error: UPGRADE FAILED: error validating "": error validating data: [ValidationError(HorizontalPodAutoscaler.spec.metrics[0].resource): unknown field "targetAverageUtilization" in io.k8s.api.autoscaling.v2.ResourceMetricSource, ValidationError(HorizontalPodAutoscaler.spec.metrics[0].resource): missing required field "target" in io.k8s.api.autoscaling.v2.ResourceMetricSource]
```

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

This bug will break configuration running Kubernetes versions >= 1.25 that are using the `.Values.autoscaling.targetCPUUtilizationPercentage` or `.Valuews.autoscaling.targetMemoryUtilizationPercentage` fields.

#### Special notes for your reviewer

I maintained the usage of the `.Values.autoscaling.targetCPUUtilizationPercentage` and `.Valuews.autoscaling.targetMemoryUtilizationPercentage` fields so this change is as seamless as possible. I ran templating tests locally and installation tests to validate that the fields populate as expected for various Kubernetes versions.

#### Checklist

- [x] Change log updated in `Chart.yaml` (see the contributing guide for details)
- [x] Chart version bumped in `Chart.yaml` (see the contributing guide for details)
- [x] Documentation regenerated by running `make docs`
