### PR TITLE
Bump Dex to v2.37.0

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: dex
-version: 0.14.3
-appVersion: "2.36.0"
+version: 0.15.0
+appVersion: "2.37.0"
 kubeVersion: ">=1.14.0-0"
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 icon: https://dexidp.io/favicon.png
@@ -21,8 +21,8 @@ maintainers:
     url: https://sagikazarmark.hu
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "Use updated HorizontalPodAutoscaler API Version which is no longer served in K8s >=1.25"
+    - kind: changed
+      description: "Update Dex to 2.37.0"
   artifacthub.io/images: |
     - name: dex
-      image: ghcr.io/dexidp/dex:v2.36.0
+      image: ghcr.io/dexidp/dex:v2.37.0

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.14.3](https://img.shields.io/badge/version-0.14.3-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.36.0](https://img.shields.io/badge/app%20version-2.36.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.15.0](https://img.shields.io/badge/version-0.15.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.37.0](https://img.shields.io/badge/app%20version-2.37.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 


### PR DESCRIPTION
#### Overview

Bump Dex to v2.37.0. The new version is out! 🚀 
