### PR TITLE
feat: Add ability to deploy extra manifests

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: dex
-version: 0.15.2
+version: 0.16.0
 appVersion: "2.37.0"
 kubeVersion: ">=1.14.0-0"
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
@@ -21,8 +21,8 @@ maintainers:
     url: https://sagikazarmark.hu
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "Fixed error stemming from the formatting of the new autoscaling API version"
+    - kind: added
+      description: "Ability to deploy extra manifests (eg. ExternalSecret, CiliumNetworkPolicy, etc.)"
   artifacthub.io/images: |
     - name: dex
       image: ghcr.io/dexidp/dex:v2.37.0

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -179,6 +179,7 @@ ingress:
 | strategy | object | `{}` | Deployment [strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) configuration. |
 | networkPolicy.enabled | bool | `false` | Create [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) |
 | networkPolicy.egressRules | list | `[]` | A list of network policy egress rules |
+| extraObjects | list | `[]` | List of extra manifests to deploy. Will be passed through `tpl` to support templating |
 
 ## Migrating from stable/dex (or banzaicloud-stable/dex) chart
 

--- a/charts/dex/templates/extra-manifests.yaml
+++ b/charts/dex/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -328,3 +328,21 @@ networkPolicy:
   #    ports:
   #      - port: 636
   #        protocol: TCP
+
+# -- List of extra manifests to deploy. Will be passed through `tpl` to support templating
+extraObjects: []
+  # - apiVersion: external-secrets.io/v1beta1
+  #   kind: ExternalSecret
+  #   metadata:
+  #     name: my-external-secret
+  #     namespace: '{{ .Release.Namespace }}'
+  #   spec:
+  #     secretStoreRef:
+  #       kind: ClusterSecretStore
+  #       name: my-secret-store
+  #     target:
+  #       name: my-kubernetes-secret
+  #     data:
+  #       - secretKey: secretKey
+  #         remoteRef:
+  #           key: /path/to/my-secret


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
5. Check out the contributing guide for more details.
-->

#### Overview

<!-- Describe your changes briefly here. -->
It is common now that helm charts offer the ability to deploy custom resources along the application. It is especially useful for managing Secrets (eg. via external-secrets.io / Secrets Store CSI Driver) or deploying more granular NetworkPolicy (eg. CiliumNetworkPolicy).

Charts in the community that supports this:
- all Argoproj charts (Argo CD, Argo workflows, ...)
- grafana charts (Grafana, Promtail, Loki, etc.)
- most Bitnami charts
- VictoriaMetrics charts
- prometheus-community charts

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
Add new parameter which allows injecting arbitrary resources.

#### Special notes for your reviewer

none

#### Checklist

- [x] Change log updated in `Chart.yaml` (see the contributing guide for details)
- [x] Chart version bumped in `Chart.yaml` (see the contributing guide for details)
- [x] Documentation regenerated by running `make docs`
