### PR TITLE
feat: Add release namespace to all resources

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: dex
-version: 0.20.0
+version: 0.21.0
 appVersion: "2.41.1"
 kubeVersion: ">=1.14.0-0"
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
@@ -21,8 +21,8 @@ maintainers:
     url: https://sagikazarmark.hu
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "`loadBalancerIP` value to control the IP when using LoadBalancer service type"
+    - kind: changed
+      description: "Add release namespace to all resources"
   artifacthub.io/images: |
     - name: dex
       image: ghcr.io/dexidp/dex:v2.41.1

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.20.0](https://img.shields.io/badge/version-0.20.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.41.1](https://img.shields.io/badge/app%20version-2.41.1-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.21.0](https://img.shields.io/badge/version-0.21.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.41.1](https://img.shields.io/badge/app%20version-2.41.1-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 
@@ -116,6 +116,7 @@ ingress:
 | image.pullPolicy | string | `"IfNotPresent"` | [Image pull policy](https://kubernetes.io/docs/concepts/containers/images/#updating-images) for updating already existing images on a node. |
 | image.tag | string | `""` | Image tag override for the default value (chart appVersion). |
 | imagePullSecrets | list | `[]` | Reference to one or more secrets to be used when [pulling images](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret) (from private registries). |
+| namespaceOverride | string | `""` | A namespace in place of the release namespace for all resources. |
 | nameOverride | string | `""` | A name in place of the chart name for `app:` labels. |
 | fullnameOverride | string | `""` | A name to substitute for the full names of resources. |
 | hostAliases | list | `[]` | A list of hosts and IPs that will be injected into the pod's hosts file if specified. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#hostname-and-name-resolution) |

--- a/charts/dex/templates/_helpers.tpl
+++ b/charts/dex/templates/_helpers.tpl
@@ -6,6 +6,31 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+Namespace for all resources to be installed into
+If not defined in values file then the helm release namespace is used
+By default this is not set so the helm release namespace will be used
+
+This gets around an problem within helm discussed here
+https://github.com/helm/helm/issues/5358
+*/}}
+{{- define "dex.namespace" -}}
+{{ .Values.namespaceOverride | default (.Release.Namespace | trunc 63 | trimSuffix "-") }}
+{{- end -}}
+
+{{/*
+    Override the namespace for the serviceMonitor
+
+    Fallback to the namespaceOverride if serviceMonitor.namespace is not set
+*/}}
+{{- define "dex.serviceMonitor.namespace" -}}
+{{- if .Values.serviceMonitor.namespace }}
+{{ .Values.serviceMonitor.namespace }}
+{{- else }}
+{{ template "dex.namespace" . }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/charts/dex/templates/deployment.yaml
+++ b/charts/dex/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "dex.fullname" . }}
+  namespace: {{ include "dex.namespace" . }}
   labels:
     {{- include "dex.labels" . | nindent 4 }}
     {{ with .Values.deploymentLabels }}

--- a/charts/dex/templates/hpa.yaml
+++ b/charts/dex/templates/hpa.yaml
@@ -7,6 +7,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "dex.fullname" . }}
+  namespace: {{ include "dex.namespace" . }}
   labels:
     {{- include "dex.labels" . | nindent 4 }}
 spec:

--- a/charts/dex/templates/ingress.yaml
+++ b/charts/dex/templates/ingress.yaml
@@ -16,6 +16,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ include "dex.namespace" . }}
   labels:
     {{- include "dex.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/dex/templates/networkpolicy.yaml
+++ b/charts/dex/templates/networkpolicy.yaml
@@ -7,6 +7,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "dex.fullname" . }}
+  namespace: {{ include "dex.namespace" . }}
   labels:
     {{- include "dex.labels" . | nindent 4 }}
 spec:

--- a/charts/dex/templates/poddisruptionbudget.yaml
+++ b/charts/dex/templates/poddisruptionbudget.yaml
@@ -7,6 +7,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "dex.fullname" . }}
+  namespace: {{ include "dex.namespace" . }}
   labels:
 {{ include "dex.labels" . | indent 4 }}
 spec:

--- a/charts/dex/templates/rbac.yaml
+++ b/charts/dex/templates/rbac.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "dex.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dex.labels" . | nindent 4 }}
 rules:
@@ -14,15 +15,16 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "dex.fullname" . }}
+  namespace: {{ include "dex.namespace" . }}
   labels:
     {{- include "dex.labels" . | nindent 4 }}
 roleRef:
   kind: Role
   apiGroup: rbac.authorization.k8s.io
-  name: {{ include "dex.fullname" . }}  
+  name: {{ include "dex.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "dex.namespace" . }}
   name: {{ include "dex.serviceAccountName" . }}
 {{- if .Values.rbac.createClusterScoped }}
 ---
@@ -49,7 +51,7 @@ roleRef:
   name: {{ include "dex.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "dex.namespace" . }}
   name: {{ include "dex.serviceAccountName" . }}
 {{- end }}
 {{- end }}

--- a/charts/dex/templates/secret.yaml
+++ b/charts/dex/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "dex.configSecretName" . }}
+  namespace: {{ include "dex.namespace" . }}
   labels:
     {{- include "dex.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/dex/templates/service.yaml
+++ b/charts/dex/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "dex.fullname" . }}
+  namespace: {{ include "dex.namespace" . }}
   labels:
     {{- include "dex.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}

--- a/charts/dex/templates/serviceaccount.yaml
+++ b/charts/dex/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "dex.serviceAccountName" . }}
+  namespace: {{ include "dex.namespace" . }}
   labels:
     {{- include "dex.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/dex/templates/servicemonitor.yaml
+++ b/charts/dex/templates/servicemonitor.yaml
@@ -7,9 +7,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   name: {{ include "dex.fullname" . }}
-  {{- with .Values.serviceMonitor.namespace }}
-  namespace: {{ . }}
-  {{- end }}
+  namespace: {{ include "dex.serviceMonitor.namespace" . }}
   labels:
     {{- include "dex.labels" . | nindent 4 }}
     {{- with .Values.serviceMonitor.labels }}
@@ -50,5 +48,5 @@ spec:
       {{- include "dex.selectorLabels" . | nindent 6 }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "dex.namespace" . }}
 {{- end }}

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -22,6 +22,9 @@ image:
 # -- Reference to one or more secrets to be used when [pulling images](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret) (from private registries).
 imagePullSecrets: []
 
+# -- A namespace in place of the release namespace for all resources.
+namespaceOverride: ""
+
 # -- A name in place of the chart name for `app:` labels.
 nameOverride: ""
 


### PR DESCRIPTION
#### Overview

This PR adds the `namespace` to all resources, using the `Relase.Namespace` provided by Helm.

#### What this PR does / why we need it

Fixes #120

As mentioned in #120 the Chart currently doesn't set the namespace on the resources, resulting in different behavior for `helm template` and `helm install` commands, as documented in https://github.com/helm/helm/issues/3553

The recommended solution by Helm is to set the namespace explicitly, as is done by a lot of other Charts (eg. cert-manager just to name one).

#### Checklist

- [x] Change log updated in `Chart.yaml` (see the contributing guide for details)
- [x] Chart version bumped in `Chart.yaml` (see the contributing guide for details)
- [x] Documentation regenerated by running `make docs`
