### PR TITLE
feat: Add .Values.service.loadBalancerIP option

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: dex
-version: 0.19.1
+version: 0.20.0
 appVersion: "2.41.1"
 kubeVersion: ">=1.14.0-0"
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
@@ -21,8 +21,8 @@ maintainers:
     url: https://sagikazarmark.hu
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Dex 2.41.1 release"
+    - kind: added
+      description: "`loadBalancerIP` value to control the IP when using LoadBalancer service type"
   artifacthub.io/images: |
     - name: dex
       image: ghcr.io/dexidp/dex:v2.41.1

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.19.1](https://img.shields.io/badge/version-0.19.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.41.1](https://img.shields.io/badge/app%20version-2.41.1-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.20.0](https://img.shields.io/badge/version-0.20.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.41.1](https://img.shields.io/badge/app%20version-2.41.1-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 
@@ -148,6 +148,7 @@ ingress:
 | service.annotations | object | `{}` | Annotations to be added to the service. |
 | service.type | string | `"ClusterIP"` | Kubernetes [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). |
 | service.clusterIP | string | `""` | Internal cluster service IP (when applicable) |
+| service.loadBalancerIP | string | `""` | Load balancer service IP (when applicable) |
 | service.ports.http.port | int | `5556` | HTTP service port |
 | service.ports.http.nodePort | int | `nil` | HTTP node port (when applicable) |
 | service.ports.https.port | int | `5554` | HTTPS service port |

--- a/charts/dex/templates/NOTES.txt
+++ b/charts/dex/templates/NOTES.txt
@@ -10,14 +10,14 @@
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
-{{- if .Values.service.loadBalancerIP }}
-     WARNING: The.spec.loadBalancerIP field for a Service was deprecated in Kubernetes v1.24.
-
-{{- end }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "dex.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "dex.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- if .Values.service.loadBalancerIP }}
+
+WARNING: The.spec.loadBalancerIP field for a Service was deprecated in Kubernetes v1.24.
+{{- end }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "dex.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")

--- a/charts/dex/templates/NOTES.txt
+++ b/charts/dex/templates/NOTES.txt
@@ -10,6 +10,10 @@
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
+{{- if .Values.service.loadBalancerIP }}
+     WARNING: The.spec.loadBalancerIP field for a Service was deprecated in Kubernetes v1.24.
+
+{{- end }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "dex.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "dex.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")

--- a/charts/dex/templates/service.yaml
+++ b/charts/dex/templates/service.yaml
@@ -13,6 +13,11 @@ spec:
   {{- with .Values.service.clusterIP }}
   clusterIP: {{ . }}
   {{- end }}
+  {{- if eq .Values.service.type "LoadBalancer" }}
+  {{- with .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
+  {{- end }}
   ports:
     - name: http
       port: {{ .Values.service.ports.http.port }}

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -162,6 +162,9 @@ service:
   # -- Internal cluster service IP (when applicable)
   clusterIP: ""
 
+  # -- Load balancer service IP (when applicable)
+  loadBalancerIP: ""
+
   ports:
     http:
       # -- HTTP service port


### PR DESCRIPTION
### Overview

Add loadBalancerIP option to manually define an IP address when service type loadBalancer is defined.

### What this PR does / why we need it

The helm chart currently has the option to define a service type but if service type is set to loadBalancer then there is no option to define a loadBalancerIP. The service type loadBalancer with loadBalancerIP option exposes the dex service externally with a defined load balancer IP for those instances where a load balancer IP cannot be assigned dynamically.

### Special notes for your reviewer

Checklist

- [x] Change log updated in Chart.yaml (see the contributing guide for details)
- [x] Chart version bumped in Chart.yaml (see the contributing guide for details)
- [x] Documentation regenerated by running make docs