### PR TITLE
feat(charts/dex): Add IPv6 and dual-stack support

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: dex
-version: 0.23.0
+version: 0.24.0
 appVersion: "2.42.0"
 kubeVersion: ">=1.14.0-0"
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
@@ -22,7 +22,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "Use tpl for dynamic image values and add digest support"
+      description: "Add support for IPv6 and IPv4/IPv6 dual-stack"
   artifacthub.io/images: |
     - name: dex
       image: ghcr.io/dexidp/dex:v2.42.0

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.23.0](https://img.shields.io/badge/version-0.23.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.42.0](https://img.shields.io/badge/app%20version-2.42.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.24.0](https://img.shields.io/badge/version-0.24.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.42.0](https://img.shields.io/badge/app%20version-2.42.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 
@@ -151,6 +151,8 @@ ingress:
 | service.type | string | `"ClusterIP"` | Kubernetes [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). |
 | service.clusterIP | string | `""` | Internal cluster service IP (when applicable) |
 | service.loadBalancerIP | string | `""` | Load balancer service IP (when applicable) |
+| service.ipFamilyPolicy | string | `""` | IP family policy (when applicable) |
+| service.ipFamilies | list | `[]` | IP families (when applicable) |
 | service.ports.http.port | int | `5556` | HTTP service port |
 | service.ports.http.nodePort | int | `nil` | HTTP node port (when applicable) |
 | service.ports.https.port | int | `5554` | HTTPS service port |

--- a/charts/dex/templates/service.yaml
+++ b/charts/dex/templates/service.yaml
@@ -19,6 +19,15 @@ spec:
   loadBalancerIP: {{ . }}
   {{- end }}
   {{- end }}
+  {{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.service.ipFamilies }}
+  ipFamilies:
+  {{- range .Values.service.ipFamilies }}
+    - {{ . }}
+  {{- end }}
+  {{- end }}
   ports:
     - name: http
       port: {{ .Values.service.ports.http.port }}

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -171,6 +171,12 @@ service:
   # -- Load balancer service IP (when applicable)
   loadBalancerIP: ""
 
+  # -- IP family policy (when applicable)
+  ipFamilyPolicy: ""
+
+  # -- IP families (when applicable)
+  ipFamilies: []
+
   ports:
     http:
       # -- HTTP service port


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
5. Check out the contributing guide for more details.
-->

#### Overview

<!-- Describe your changes briefly here. -->

Add support to set `ipFamilyPolicy` and `ipFamilies` fields for the Dex service.

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

It is currently not possible to set the `ipFamilyPolicy` and `ipFamilies` fields, which are required to enable IPv6 or dual-stack support for the service. This change adds the possibility to set these fields.

#### Special notes for your reviewer

#### Checklist

- [X] Change log updated in `Chart.yaml` (see the contributing guide for details)
- [X] Chart version bumped in `Chart.yaml` (see the contributing guide for details)
- [X] Documentation regenerated by running `make docs`
