### PR TITLE
feat: Allow to use HTTPRoute from Gateway API.

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: dex
-version: 0.24.0
+version: 0.24.1
 appVersion: "2.44.0"
 kubeVersion: ">=1.14.0-0"
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.24.0](https://img.shields.io/badge/version-0.24.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.44.0](https://img.shields.io/badge/app%20version-2.44.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.24.1](https://img.shields.io/badge/version-0.24.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.44.0](https://img.shields.io/badge/app%20version-2.44.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 
@@ -162,6 +162,11 @@ ingress:
 | ingress.annotations | object | `{}` | Annotations to be added to the ingress. |
 | ingress.hosts | list | See [values.yaml](values.yaml). | Ingress host configuration. |
 | ingress.tls | list | See [values.yaml](values.yaml). | Ingress TLS configuration. |
+| httpRoute.enabled | bool | `false` | Enable Gateway API HTTPRoute. Gateway API support is in EXPERIMENTAL status. Support depends on your Gateway controller implementation. See the [Gateway API documentation](https://gateway-api.sigs.k8s.io/) for details. |
+| httpRoute.annotations | object | `{}` | Annotations to be added to the HTTPRoute. |
+| httpRoute.parentRefs | list | `[]` | References to the Gateway(s) that this HTTPRoute is attached to. See the [API reference](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.ParentReference) for details. |
+| httpRoute.hostnames | list | `["chart-example.local"]` | Hostnames defines the hostnames for routing. See the [API reference](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Hostname) for details. |
+| httpRoute.rules | list | `[{"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | HTTPRoute rules configuration. See the [API reference](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteRule) for details. |
 | serviceMonitor.enabled | bool | `false` | Enable Prometheus ServiceMonitor. See the [documentation](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/design.md#servicemonitor) and the [API reference](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor) for details. |
 | serviceMonitor.namespace | string | Release namespace. | Namespace where the ServiceMonitor resource should be deployed. |
 | serviceMonitor.interval | duration | `nil` | Prometheus scrape interval. |

--- a/charts/dex/templates/httproute.yaml
+++ b/charts/dex/templates/httproute.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "dex.fullname" . -}}
+{{- $svcPort := .Values.service.ports.http.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "dex.namespace" . }}
+  labels:
+    {{- include "dex.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.httpRoute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+      backendRefs:
+        - group: ''
+          kind: Service
+          name: {{ $fullName }}
+          port: {{ $svcPort }}
+          weight: 1
+    {{- end }}
+{{- end }}

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -220,6 +220,41 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+httpRoute:
+  # -- Enable Gateway API HTTPRoute.
+  # Gateway API support is in EXPERIMENTAL status. Support depends on your Gateway controller implementation.
+  # See the [Gateway API documentation](https://gateway-api.sigs.k8s.io/) for details.
+  enabled: false
+
+  # -- Annotations to be added to the HTTPRoute.
+  annotations: {}
+
+  # -- References to the Gateway(s) that this HTTPRoute is attached to.
+  # See the [API reference](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.ParentReference) for details.
+  parentRefs: []
+    # - name: gateway
+    # namespace: gateway-system
+    # sectionName: https
+    # port: 443
+
+  # -- Hostnames defines the hostnames for routing.
+  # See the [API reference](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Hostname) for details.
+  hostnames:
+    - chart-example.local
+
+  # -- HTTPRoute rules configuration.
+  # See the [API reference](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteRule) for details.
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      # filters:
+      #   - type: RequestHeaderModifier
+      #     requestHeaderModifier:
+      #       add:
+      #         - name: X-Custom-Header
+      #           value: custom-value
 serviceMonitor:
   # -- Enable Prometheus ServiceMonitor.
   # See the [documentation](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/design.md#servicemonitor) and the [API reference](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor) for details.


### PR DESCRIPTION
#### Overview

Support for kubernetes Gateway API, customer can use HTTPRoute instead of Ingress (all credits goes to @abelhoula).

#### What this PR does / why we need it

HTTPRoute manifest added.

#### Special notes for your reviewer

#### Checklist

- [/] Change log updated in `Chart.yaml` (see the contributing guide for details)
- [/] Chart version bumped in `Chart.yaml` (see the contributing guide for details)
- [/] Documentation regenerated by running `make docs`
