### PR TITLE
chore: update Dex to 2.45.1

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: dex
-version: 0.24.0
-appVersion: "2.44.0"
+version: 0.25.0
+appVersion: "2.45.1"
 kubeVersion: ">=1.14.0-0"
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 icon: https://dexidp.io/favicons/favicon.png
@@ -22,7 +22,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update Dex to 2.44.0"
+      description: "Update Dex to 2.45.1"
   artifacthub.io/images: |
     - name: dex
-      image: ghcr.io/dexidp/dex:v2.44.0
+      image: ghcr.io/dexidp/dex:v2.45.1

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.24.0](https://img.shields.io/badge/version-0.24.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.44.0](https://img.shields.io/badge/app%20version-2.44.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.25.0](https://img.shields.io/badge/version-0.25.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.45.1](https://img.shields.io/badge/app%20version-2.45.1-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 


### PR DESCRIPTION
#### Overview                                                                                                     
               
  Updating dex to 2.45.1:                                                                                             
  https://github.com/dexidp/dex/releases/tag/v2.45.1
                                                                                                                      
  #### What this PR does / why we need it                                                                             
                                                                                                                      
  There's a new dex version which we should make available via the helm chart.                                        
  This rolls up both v2.45.0 and v2.45.1 since the chart hasn't been bumped since v2.44.0.                            
                                                                                          
  #### Special notes for your reviewer                                                                                
                                                                                                                      
  Verified locally:                                                                                                   
  - `ghcr.io/dexidp/dex:v2.45.1` image is published and pullable                                                      
  - `helm lint charts/dex` passes                               
  - `helm template charts/dex` renders the new image tag correctly                                                    
  - `make docs` regenerates `charts/dex/README.md` cleanly                                                            
                                                                                                                      
  #### Checklist                                                                                                      
                                                                                                                      
  - [x] Change log updated in `Chart.yaml` (see the contributing guide for details)                                   
  - [x] Chart version bumped in `Chart.yaml` (see the contributing guide for details)                                 
  - [x] Documentation regenerated by running `make docs`  