### PR TITLE
Add Knative support to dex chart

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: dex
-version: 0.24.1
+version: 0.25.0
 appVersion: "2.44.0"
 kubeVersion: ">=1.14.0-0"
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
@@ -21,8 +21,8 @@ maintainers:
     url: https://sagikazarmark.com
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Update Dex to 2.44.0"
+    - kind: added
+      description: "Add optional Knative Service rendering support"
   artifacthub.io/images: |
     - name: dex
       image: ghcr.io/dexidp/dex:v2.44.0

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.24.1](https://img.shields.io/badge/version-0.24.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.44.0](https://img.shields.io/badge/app%20version-2.44.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.25.0](https://img.shields.io/badge/version-0.25.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.44.0](https://img.shields.io/badge/app%20version-2.44.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 
@@ -106,6 +106,26 @@ ingress:
       secretName: dex-cert
 ```
 
+### Knative configuration
+
+This chart can render a Knative `Service` instead of the default Kubernetes `Deployment` and `Service`:
+
+```yaml
+knative:
+  enabled: true
+
+config:
+  issuer: https://dex.example.com
+
+  storage:
+    type: memory
+
+  enablePasswordDB: true
+```
+
+In Knative mode, Dex serves on its HTTP endpoint (`5556`) and exposes telemetry on `5558` for health probes.
+Knative manages routing and autoscaling for the workload, so Kubernetes-level features such as `ingress`, `httpRoute`, `autoscaling`, and `podDisruptionBudget` are not used and should be left disabled.
+
 ## Values
 
 | Key | Type | Default | Description |
@@ -123,6 +143,14 @@ ingress:
 | hostAliases | list | `[]` | A list of hosts and IPs that will be injected into the pod's hosts file if specified. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#hostname-and-name-resolution) |
 | https.enabled | bool | `false` | Enable the HTTPS endpoint. |
 | grpc.enabled | bool | `false` | Enable the gRPC endpoint. Read more in the [documentation](https://dexidp.io/docs/api/). |
+| knative.enabled | bool | `false` | Enable rendering a Knative Service instead of a Kubernetes Deployment and Service. |
+| knative.annotations | object | `{}` | Additional annotations to add to the Knative revision template, for example autoscaling options not covered by `knative.autoscaling`. |
+| knative.containerConcurrency | int | `0` | Hard limit for the number of concurrent requests processed by each replica. A value of 0 means unlimited. |
+| knative.timeoutSeconds | int | `nil` | Maximum duration in seconds that an in-flight request is allowed to run. |
+| knative.responseStartTimeoutSeconds | int | `nil` | Maximum duration in seconds the Knative queue proxy waits for a response to start. |
+| knative.idleTimeoutSeconds | int | `nil` | Maximum duration in seconds an idle connection is kept open. |
+| knative.autoscaling.minScale | int | `nil` | Minimum number of replicas for each Knative revision. |
+| knative.autoscaling.maxScale | int | `nil` | Maximum number of replicas for each Knative revision. |
 | configSecret.create | bool | `true` | Enable creating a secret from the values passed to `config`. If set to false, name must point to an existing secret. |
 | configSecret.name | string | `""` | The name of the secret to mount as configuration in the pod. If not set and create is true, a name is generated using the fullname template. Must point to secret that contains at least a `config.yaml` key. |
 | config | object | `{}` | Application configuration. See the [official documentation](https://dexidp.io/docs/). |

--- a/charts/dex/README.md.gotmpl
+++ b/charts/dex/README.md.gotmpl
@@ -93,6 +93,26 @@ ingress:
       secretName: dex-cert
 ```
 
+### Knative configuration
+
+This chart can render a Knative `Service` instead of the default Kubernetes `Deployment` and `Service`:
+
+```yaml
+knative:
+  enabled: true
+
+config:
+  issuer: https://dex.example.com
+
+  storage:
+    type: memory
+
+  enablePasswordDB: true
+```
+
+In Knative mode, Dex serves on its HTTP endpoint (`5556`) and exposes telemetry on `5558` for health probes.
+Knative manages routing and autoscaling for the workload, so Kubernetes-level features such as `ingress`, `httpRoute`, `autoscaling`, and `podDisruptionBudget` are not used and should be left disabled.
+
 {{ template "chart.valuesSection" . }}
 
 ## Migrating from stable/dex (or banzaicloud-stable/dex) chart

--- a/charts/dex/templates/NOTES.txt
+++ b/charts/dex/templates/NOTES.txt
@@ -1,5 +1,7 @@
 1. Get the application URL by running these commands:
-{{- if .Values.ingress.enabled }}
+{{- if .Values.knative.enabled }}
+  kubectl get ksvc {{ include "dex.fullname" . }} --namespace {{ include "dex.namespace" . }} -o jsonpath='{.status.url}{"\n"}'
+{{- else if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range .paths }}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}

--- a/charts/dex/templates/hpa.yaml
+++ b/charts/dex/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.autoscaling.enabled }}
+{{- if and .Values.autoscaling.enabled (not .Values.knative.enabled) }}
 {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: autoscaling/v2
 {{- else -}}

--- a/charts/dex/templates/knative-service.yaml
+++ b/charts/dex/templates/knative-service.yaml
@@ -1,30 +1,19 @@
-{{- if not .Values.knative.enabled }}
-apiVersion: apps/v1
-kind: Deployment
+{{- if .Values.knative.enabled }}
+apiVersion: serving.knative.dev/v1
+kind: Service
 metadata:
   name: {{ include "dex.fullname" . }}
   namespace: {{ include "dex.namespace" . }}
   labels:
     {{- include "dex.labels" . | nindent 4 }}
-    {{ with .Values.deploymentLabels }}
+    {{- with .Values.deploymentLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{ with .Values.deploymentAnnotations }}
+  {{- with .Values.deploymentAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
-  {{- end }}
-  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  {{- with .Values.strategy }}
-  strategy:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-  selector:
-    matchLabels:
-      {{- include "dex.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -34,12 +23,31 @@ spec:
       {{ if .Values.configSecret.create }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       {{- end }}
+      {{- with .Values.knative.autoscaling.minScale }}
+        autoscaling.knative.dev/min-scale: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.knative.autoscaling.maxScale }}
+        autoscaling.knative.dev/max-scale: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.knative.annotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "dex.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      containerConcurrency: {{ .Values.knative.containerConcurrency }}
+      {{- with .Values.knative.timeoutSeconds }}
+      timeoutSeconds: {{ . }}
+      {{- end }}
+      {{- with .Values.knative.responseStartTimeoutSeconds }}
+      responseStartTimeoutSeconds: {{ . }}
+      {{- end }}
+      {{- with .Values.knative.idleTimeoutSeconds }}
+      idleTimeoutSeconds: {{ . }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -48,16 +56,20 @@ spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.image.digest }}
           image: "{{ tpl .Values.image.repository . }}@{{ tpl .Values.image.digest . }}"
           {{- else }}
@@ -69,14 +81,6 @@ spec:
             - serve
             - --web-http-addr
             - 0.0.0.0:5556
-            {{- if .Values.https.enabled }}
-            - --web-https-addr
-            - 0.0.0.0:5554
-            {{- end }}
-            {{- if .Values.grpc.enabled }}
-            - --grpc-addr
-            - 0.0.0.0:5557
-            {{- end }}
             - --telemetry-addr
             - 0.0.0.0:5558
             - /etc/dex/config.yaml
@@ -93,30 +97,16 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
-            - name: http
+            - name: http1
               containerPort: 5556
               protocol: TCP
-            {{- if .Values.https.enabled }}
-            - name: https
-              containerPort: 5554
-              protocol: TCP
-            {{- end }}
-            {{- if .Values.grpc.enabled }}
-            - name: grpc
-              containerPort: 5557
-              protocol: TCP
-            {{- end }}
-            - name: telemetry
-              containerPort: 5558
-              protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /healthz/live
-              port: telemetry
+            tcpSocket:
+              port: 5556
           readinessProbe:
             httpGet:
               path: /healthz/ready
-              port: telemetry
+              port: 5558
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/dex/templates/networkpolicy.yaml
+++ b/charts/dex/templates/networkpolicy.yaml
@@ -21,6 +21,12 @@ spec:
       {{- include "dex.selectorLabels" . | nindent 6 }}
   ingress:
     - ports:
+        {{- if .Values.knative.enabled }}
+        - port: 8012
+        - port: 8112
+        - port: 9090
+        - port: 9091
+        {{- else }}
         - port: http
         {{- if .Values.https.enabled }}
         - port: https
@@ -29,6 +35,7 @@ spec:
         - port: grpc
         {{- end }}
         - port: telemetry
+        {{- end }}
   {{- with .Values.networkPolicy.egressRules }}
   egress:
     {{- toYaml . | nindent 4 }}

--- a/charts/dex/templates/service.yaml
+++ b/charts/dex/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.knative.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -63,3 +64,4 @@ spec:
       {{- end }}
   selector:
     {{- include "dex.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/dex/templates/validate.yaml
+++ b/charts/dex/templates/validate.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.knative.enabled .Values.autoscaling.enabled -}}
+{{- fail "autoscaling.enabled cannot be used with knative.enabled; use knative.autoscaling instead" -}}
+{{- end -}}
+{{- if and .Values.knative.enabled .Values.ingress.enabled -}}
+{{- fail "ingress.enabled cannot be used with knative.enabled; use the Knative Service route instead" -}}
+{{- end -}}
+{{- if and .Values.knative.enabled .Values.httpRoute.enabled -}}
+{{- fail "httpRoute.enabled cannot be used with knative.enabled; use the Knative Service route instead" -}}
+{{- end -}}
+{{- if and .Values.knative.enabled .Values.serviceMonitor.enabled -}}
+{{- fail "serviceMonitor.enabled cannot be used with knative.enabled because Knative does not expose dex's telemetry port through a Kubernetes Service" -}}
+{{- end -}}
+{{- if and .Values.knative.enabled (or .Values.https.enabled .Values.grpc.enabled) -}}
+{{- fail "https.enabled and grpc.enabled cannot be used with knative.enabled because Knative Serving allows only one exposed container port" -}}
+{{- end -}}

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -47,6 +47,34 @@ grpc:
   # Read more in the [documentation](https://dexidp.io/docs/api/).
   enabled: false
 
+knative:
+  # -- Enable rendering a Knative Service instead of a Kubernetes Deployment and Service.
+  enabled: false
+
+  # -- Additional annotations to add to the Knative revision template,
+  # for example autoscaling options not covered by `knative.autoscaling`.
+  annotations: {}
+
+  # -- Hard limit for the number of concurrent requests processed by each replica.
+  # A value of 0 means unlimited.
+  containerConcurrency: 0
+
+  # -- (int) Maximum duration in seconds that an in-flight request is allowed to run.
+  timeoutSeconds:
+
+  # -- (int) Maximum duration in seconds the Knative queue proxy waits for a response to start.
+  responseStartTimeoutSeconds:
+
+  # -- (int) Maximum duration in seconds an idle connection is kept open.
+  idleTimeoutSeconds:
+
+  autoscaling:
+    # -- (int) Minimum number of replicas for each Knative revision.
+    minScale:
+
+    # -- (int) Maximum number of replicas for each Knative revision.
+    maxScale:
+
 configSecret:
   # -- Enable creating a secret from the values passed to `config`.
   # If set to false, name must point to an existing secret.


### PR DESCRIPTION
#### Overview

Add optional Knative Service support to the dex Helm chart.

#### What this PR does / why we need it

- Adds `knative.enabled` to render a Knative `Service` instead of the default Kubernetes `Deployment` and `Service`.
- Supports Knative revision settings such as annotations, container concurrency, timeouts, and min/max scale.
- Enables Knative-managed routing and autoscaling, including scale-to-zero for idle development or off-hours environments.
- Lets Knative buffer requests during sudden traffic spikes, reducing direct pressure on dex while new replicas are started.
- Updates install notes and documentation for Knative mode.
- Bumps the chart version to `0.25.0` and adds an Artifact Hub changelog entry.

#### Special notes for your reviewer

When `knative.enabled=true`, Kubernetes `ingress`, `httpRoute`, `autoscaling`, and `podDisruptionBudget` should remain disabled because Knative manages routing, request buffering, and autoscaling for the workload.

#### Checklist

- [x] Change log updated in `Chart.yaml` (see the contributing guide for details)
- [x] Chart version bumped in `Chart.yaml` (see the contributing guide for details)
- [x] Documentation regenerated by running `make docs`
